### PR TITLE
Add support for app name in user agent, and some defaults

### DIFF
--- a/config/nexmo.php
+++ b/config/nexmo.php
@@ -42,4 +42,16 @@ return [
     'private_key' => function_exists('env') ? env('NEXMO_PRIVATE_KEY', '') : '',
     'application_id' => function_exists('env') ? env('NEXMO_APPLICATION_ID', '') : '',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Application Identifiers
+    |--------------------------------------------------------------------------
+    |
+    | Add an application name and version here to identify your application when
+    | making API calls
+    |
+    */
+
+    'app' => ['name' => function_exists('env') ? env('NEXMO_APP_NAME', 'NexmoLaravel') : 'NexmoLaravel',
+        'version' => function_exists('env') ? env('NEXMO_APP_VERSION', '1.1.2') : '1.1.2']
 ];

--- a/src/NexmoServiceProvider.php
+++ b/src/NexmoServiceProvider.php
@@ -78,7 +78,7 @@ class NexmoServiceProvider extends ServiceProvider
         }
 
         // Get Client Options.
-        $options = array_diff_key($config->get('nexmo'), ['private_key', 'application_id', 'api_key', 'api_secret', 'shared_secret']);
+        $options = array_diff_key($config->get('nexmo'), ['private_key', 'application_id', 'api_key', 'api_secret', 'shared_secret', 'app']);
 
         // Do we have a private key?
         $privateKeyCredentials = null;


### PR DESCRIPTION
I've defaulted the app version to 1.1.2 which I guess will be our next release - but we could do with a better way to keep this in sync in future. Related to https://github.com/Nexmo/nexmo-php/pull/112 but I think this change is still an improvement.