### PR TITLE
Add ValidSignatureRequest form request

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,4 +202,27 @@ Nexmo::calls()->create([
 
 For more information on using the Nexmo client library, see the [official client library repository][client-library].
 
+Laravel Helpers
+---------------
+
+In addition to a Facade, this library provides validation rules and form requests for validating message signatures to ensure that a webhook originates from Nexmo.
+
+The easiest way to use this functionality is to type hint on the `Nexmo\Laravel\ValidSignatureRequest` form request which takes care of everything for you:
+
+```php
+use Nexmo\Laravel\ValidSignatureRequest;
+
+Route::post('/webhooks/inbound-sms', function (ValidSignatureRequest $request) {
+    // If we get this far the signature is valid and the data can be trusted
+});
+```
+
+If you'd like slightly more control and want to perform additional validation, you can use the `nexmo_signature` validation rule like so:
+
+```php
+Validator::make(request()->all(), [
+    'sig' => 'nexmo_signature'
+])->validate();
+```
+
 [client-library]: https://github.com/Nexmo/nexmo-php

--- a/config/nexmo.php
+++ b/config/nexmo.php
@@ -27,6 +27,7 @@ return [
     */
 
     'signature_secret' => function_exists('env') ? env('NEXMO_SIGNATURE_SECRET', '') : '',
+    'signature_method' => function_exists('env') ? env('NEXMO_SIGNATURE_METHOD', '') : '',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/NexmoServiceProvider.php
+++ b/src/NexmoServiceProvider.php
@@ -4,8 +4,10 @@ namespace Nexmo\Laravel;
 
 use Nexmo\Client;
 use Illuminate\Support\Str;
+use Nexmo\Client\Signature;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Support\Facades\Validator;
 
 class NexmoServiceProvider extends ServiceProvider
 {
@@ -37,6 +39,23 @@ class NexmoServiceProvider extends ServiceProvider
 
         // Merge config.
         $this->mergeConfigFrom($dist, 'nexmo');
+
+        // Add a new validation rule for validating signatures
+        // Implicit means that it runs even if the sig field is not sent
+        Validator::extendImplicit('nexmo_signature', function ($attribute, $value, $parameters, $validator) {
+            $data = $validator->getData();
+
+            if (!isset($data['sig'])) {
+                return false;
+            }
+
+            $signature = new Signature(
+                $data,
+                config('nexmo.signature_secret'),
+                config('nexmo.signature_method')
+            );
+            return $signature->check($data['sig']);
+        });
     }
 
     /**

--- a/src/ValidSignatureRequest.php
+++ b/src/ValidSignatureRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Nexmo\Laravel;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Validation\ValidationException;
+
+class ValidSignatureRequest extends FormRequest {
+
+    public function authorize() {
+        return true;
+    }
+
+    public function rules() {
+        return [
+            'sig' => ['nexmo_signature']
+        ];
+    }
+
+    protected function failedValidation(Validator $validator) {
+        // We set an explicit response here to prevent the redirect 
+        // that usually happens
+        $response = response()->json('Signature is invalid', 422);
+        throw new ValidationException($validator, $response);
+    }
+}

--- a/tests/TestClientPrivateKeySignatureCredentials.php
+++ b/tests/TestClientPrivateKeySignatureCredentials.php
@@ -19,6 +19,7 @@ class TestClientPrivateKeySignatureCredentials extends AbstractTestCase
         $app['config']->set('nexmo.application_id', 'application-id-123');
         $app['config']->set('nexmo.api_key', 'my_api_key');
         $app['config']->set('nexmo.signature_secret', 'my_signature');
+        $app['config']->set('nexmo.signature_method', 'md5hash');
     }
 
     /**

--- a/tests/TestClientSignatureAPICredentials.php
+++ b/tests/TestClientSignatureAPICredentials.php
@@ -3,6 +3,7 @@
 namespace Nexmo\Laravel\Tests;
 
 use Nexmo\Client;
+use Illuminate\Support\Facades\Validator;
 
 class TestClientSignatureAPICredentials extends AbstractTestCase
 {
@@ -17,6 +18,7 @@ class TestClientSignatureAPICredentials extends AbstractTestCase
     {
         $app['config']->set('nexmo.api_key', 'my_api_key');
         $app['config']->set('nexmo.signature_secret', 'my_signature');
+        $app['config']->set('nexmo.signature_method', 'md5hash');
     }
 
     /**
@@ -34,5 +36,31 @@ class TestClientSignatureAPICredentials extends AbstractTestCase
 
         $this->assertInstanceOf(Client\Credentials\SignatureSecret::class, $credentialsObject);
         $this->assertEquals(['api_key' => 'my_api_key', 'signature_secret' => 'my_signature', 'signature_method' => 'md5hash'], $credentialsArray);
+    }
+
+    /*
+     * Test that the `nexmo_signature` validation rule is
+     * accessible when using Validator::make().
+     */
+    public function testValidationExtensionIsRegistered()
+    {
+        $actual = Validator::make(['sig' => 'invalid_sig'], [
+            'sig' => 'nexmo_signature'
+        ])->passes();
+
+        $this->assertFalse($actual);
+    }
+
+    /*
+     * Now that we know it's registered, we need to make sure that
+     * it runs implicitly when data is not provided
+     */
+    public function testValidationExtensionIsRegisteredImplicitly()
+    {
+        $actual = Validator::make([], [
+            'sig' => 'nexmo_signature'
+        ])->passes();
+
+        $this->assertFalse($actual);
     }
 }

--- a/tests/TestValidSignatureRequest.php
+++ b/tests/TestValidSignatureRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Nexmo\Laravel\Tests;
+
+use Nexmo\Client;
+use Nexmo\Laravel\ValidSignatureRequest;
+use Illuminate\Support\Facades\Validator;
+
+class TestValidSignatureRequest extends AbstractTestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application $app
+     *
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('nexmo.signature_secret', '71efab63122f1d179f51c46bac838fb5');
+        $app['config']->set('nexmo.signature_method', 'sha256');
+
+        \Route::post('/test-valid-signature', function (ValidSignatureRequest $request) {
+            return response()->json("The data can be trusted");
+        });
+    }
+
+    public function testFailsWithInvalidData()
+    {
+        $response = $this->call('POST', '/test-valid-signature', ['sig' => 'invalid']);
+        $response->assertStatus(422);
+    }
+
+    public function testPassesWithValidData()
+    {
+        $response = $this->call('POST', '/test-valid-signature', array (
+            'sig' => '9FEC5EF6D0F2B3D2BB7558B6E4042569823CAB9EA0DD30503472B7B304601975',
+            'api_key' => 'fake_api_key',
+            'to' => '14155550100',
+            'from' => 'AcmeInc',
+            'text' => 'Test From Nexmo',
+            'type' => 'text',
+            'timestamp' => '1540924779',
+        ));
+        $response->assertStatus(200);
+    }
+}
+


### PR DESCRIPTION
This allows customers to type hint on
\Nexmo\Laravel\ValidSignatureRequest in any route and their application
will automatically validate any webhook requests using their signature
secret

If the user wants more control, they can use the `nexmo_signature`
validation rule when calling Validation::make()