### PR TITLE
Support private key as environment variable

### DIFF
--- a/src/NexmoServiceProvider.php
+++ b/src/NexmoServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Nexmo\Laravel;
 
 use Nexmo\Client;
+use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Config\Repository as Config;
 

--- a/src/NexmoServiceProvider.php
+++ b/src/NexmoServiceProvider.php
@@ -241,6 +241,10 @@ class NexmoServiceProvider extends ServiceProvider
             return '===FAKE-KEY===';
         }
 
+        if (Str::startsWith($key, '-----BEGIN PRIVATE KEY-----')) {
+            return $key;
+        }
+
         // If it's a relative path, start searching in the
         // project root
         if ($key[0] !== '/') {


### PR DESCRIPTION
If the environment variable `NEXMO_PRIVATE_KEY` *is* the private key, rather than the path to a file that is the private key it should just be used as-is. I'm not sure if there is a better way to determine if a string is a private key but using `Str::startsWith()` is a pretty simple check.

Supporting this will make it much simpler to use private keys, but also makes the configuration much more in line with Laravel conventions.