### PR TITLE
Require `nexmo/client-core` directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^5.6|^7.1",
         "illuminate/support": "^5.2|^6.0|^7.0",
-        "nexmo/client": "^2.0"
+        "nexmo/client-core": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.3|~6.0|~8.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "require": {
         "php": "^5.6|^7.1",
         "illuminate/support": "^5.2|^6.0|^7.0",
-        "nexmo/client-core": "^2.0"
+        "nexmo/client-core": "^2.0",
+        "php-http/guzzle6-adapter": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.3|~6.0|~8.0",


### PR DESCRIPTION
`nexmo/client` is lagging a bit behind `nexmo/client-core` (no stable 2.0 version yet). Since it's just an empty package I think we can safely use `nexmo/client-core` directly here. I've also directly required the Guzzle adapter here instead. This was the `nexmo-laravel` package has one less package in between and you don't have to worry about tagging `nexmo/client` anymore.