### PR TITLE
Fixed tests to support \Nexmo and \Vonage

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Environment name and version (e.g. PHP 7.2 on nginx 1.19.1):
+* Operating System and version:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Example Output or Screenshots (if appropriate):
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+---
+name: build
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ '7.2', '7.3', '7.4' ]
+    continue-on-error: ${{ matrix.php == '8.0' }}
+    name: PHP ${{ matrix.php }} Test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, mbstring
+          coverage: pcov
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Get Composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Analyze & test
+        run: composer test -- -v --coverage-clover=coverage.xml
+
+      - name: Run codecov
+        uses: codecov/codecov-action@v1

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^5.6|^7.1",
         "illuminate/support": "^5.2|^6.0|^7.0|^8.0",
-        "nexmo/client": "^2.0"
+        "vonage/client": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.3|~6.0|~8.0",

--- a/composer.json
+++ b/composer.json
@@ -54,5 +54,8 @@
                 "Nexmo": "Nexmo\\Laravel\\Facade\\Nexmo"
             }
         }
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Nexmo Laravel Suite">

--- a/src/NexmoServiceProvider.php
+++ b/src/NexmoServiceProvider.php
@@ -2,7 +2,8 @@
 
 namespace Nexmo\Laravel;
 
-use Nexmo\Client;
+use Vonage\Client;
+use Nexmo\Client as NexmoClient;
 use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Config\Repository as Config;
@@ -50,6 +51,9 @@ class NexmoServiceProvider extends ServiceProvider
         $this->app->singleton(Client::class, function ($app) {
             return $this->createNexmoClient($app['config']);
         });
+        $this->app->singleton(NexmoClient::class, function ($app) {
+            return $this->createNexmoClient($app['config']);
+        });
     }
 
     /**
@@ -59,7 +63,10 @@ class NexmoServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return [Client::class];
+        return [
+            Client::class,
+            NexmoClient::class
+        ];
     }
 
     /**

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -4,6 +4,8 @@ namespace Nexmo\Laravel\Tests;
 
 use Orchestra\Testbench\TestCase;
 use Nexmo\Laravel\NexmoServiceProvider;
+use Vonage\Client;
+use Nexmo\Client as NexmoClient;
 
 abstract class AbstractTestCase extends TestCase
 {
@@ -51,5 +53,16 @@ abstract class AbstractTestCase extends TestCase
         $refProperty->setAccessible(true);
 
         return $refProperty->getValue($object);
+    }
+
+    /**
+     * Returns a list of classes we should attempt to create
+     */
+    public function classNameProvider(): array
+    {
+        return [
+            [Client::class],
+            [NexmoClient::class],
+        ];
     }
 }

--- a/tests/TestClientBasicAPICredentials.php
+++ b/tests/TestClientBasicAPICredentials.php
@@ -2,7 +2,7 @@
 
 namespace Nexmo\Laravel\Tests;
 
-use Nexmo\Client;
+use Vonage\Client;
 
 class TestClientBasicAPICredentials extends AbstractTestCase
 {

--- a/tests/TestClientPrivateKeyBasicCredentials.php
+++ b/tests/TestClientPrivateKeyBasicCredentials.php
@@ -2,7 +2,7 @@
 
 namespace Nexmo\Laravel\Tests;
 
-use Nexmo\Client;
+use Vonage\Client;
 
 class TestClientPrivateKeyBasicCredentials extends AbstractTestCase
 {
@@ -25,13 +25,14 @@ class TestClientPrivateKeyBasicCredentials extends AbstractTestCase
      * Test that our Nexmo client is created with
      * a container with key + basic credentials.
      *
+     * @dataProvider classNameProvider
+     *
      * @return void
      */
-    public function testClientCreatedWithPrivateKeyBasicCredentials()
+    public function testClientCreatedWithPrivateKeyBasicCredentials($className)
     {
-        $client = app(Client::class);
+        $client = app($className);
         $credentialsObject = $this->getClassProperty(Client::class, 'credentials', $client);
-
         $credentialsArray = $this->getClassProperty(Client\Credentials\Container::class, 'credentials', $credentialsObject);
         $keypairCredentials = $this->getClassProperty(Client\Credentials\Keypair::class, 'credentials', $credentialsArray[Client\Credentials\Keypair::class]);
         $basicCredentials = $this->getClassProperty(Client\Credentials\Basic::class, 'credentials', $credentialsArray[Client\Credentials\Basic::class]);

--- a/tests/TestClientPrivateKeyCredentials.php
+++ b/tests/TestClientPrivateKeyCredentials.php
@@ -2,7 +2,7 @@
 
 namespace Nexmo\Laravel\Tests;
 
-use Nexmo\Client;
+use Vonage\Client;
 
 class TestClientPrivateKeyCredentials extends AbstractTestCase
 {
@@ -23,11 +23,12 @@ class TestClientPrivateKeyCredentials extends AbstractTestCase
      * Test that our Nexmo client is created with
      * the private key credentials
      *
+     * @dataProvider classNameProvider
      * @return void
      */
-    public function testClientCreatedWithPrivateKeyCredentials()
+    public function testClientCreatedWithPrivateKeyCredentials($className)
     {
-        $client = app(Client::class);
+        $client = app($className);
         $credentialsObject = $this->getClassProperty(Client::class, 'credentials', $client);
         $credentialsArray = $this->getClassProperty(Client\Credentials\Keypair::class, 'credentials', $credentialsObject);
 

--- a/tests/TestClientPrivateKeySignatureCredentials.php
+++ b/tests/TestClientPrivateKeySignatureCredentials.php
@@ -2,7 +2,7 @@
 
 namespace Nexmo\Laravel\Tests;
 
-use Nexmo\Client;
+use Vonage\Client;
 
 class TestClientPrivateKeySignatureCredentials extends AbstractTestCase
 {
@@ -25,11 +25,13 @@ class TestClientPrivateKeySignatureCredentials extends AbstractTestCase
      * Test that our Nexmo client is created with
      * a container with private key + signature credentials
      *
+     * @dataProvider classNameProvider
+     *
      * @return void
      */
-    public function testClientCreatedWithPrivateKeySignatureCredentials()
+    public function testClientCreatedWithPrivateKeySignatureCredentials($className)
     {
-        $client = app(Client::class);
+        $client = app($className);
         $credentialsObject = $this->getClassProperty(Client::class, 'credentials', $client);
 
         $credentialsArray = $this->getClassProperty(Client\Credentials\Container::class, 'credentials', $credentialsObject);

--- a/tests/TestClientSignatureAPICredentials.php
+++ b/tests/TestClientSignatureAPICredentials.php
@@ -2,7 +2,7 @@
 
 namespace Nexmo\Laravel\Tests;
 
-use Nexmo\Client;
+use Vonage\Client;
 
 class TestClientSignatureAPICredentials extends AbstractTestCase
 {
@@ -23,11 +23,12 @@ class TestClientSignatureAPICredentials extends AbstractTestCase
      * Test that our Nexmo client is created with
      * the signature credentials
      *
+     * @dataProvider classNameProvider
      * @return void
      */
-    public function testClientCreatedWithSignatureAPICredentials()
+    public function testClientCreatedWithSignatureAPICredentials($className)
     {
-        $client = app(Client::class);
+        $client = app($className);
 
         $credentialsObject = $this->getClassProperty(Client::class, 'credentials', $client);
         $credentialsArray = $this->getClassProperty(Client\Credentials\SignatureSecret::class, 'credentials', $credentialsObject);

--- a/tests/TestNoNexmoConfiguration.php
+++ b/tests/TestNoNexmoConfiguration.php
@@ -2,7 +2,7 @@
 
 namespace Nexmo\Laravel\Tests;
 
-use Nexmo\Client;
+use Vonage\Client;
 
 class TestNoNexmoConfiguration extends AbstractTestCase
 {
@@ -20,15 +20,17 @@ class TestNoNexmoConfiguration extends AbstractTestCase
 
     /**
      * Test that when we do not supply Nexmo configuration
-     * a Runtime exception is generated.
+     * a Runtime exception is generated under the Vonage namespace.
+     *
+     * @dataProvider classNameProvider
      *
      * @return void
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Please provide Nexmo API credentials. Possible combinations: api_key + api_secret, api_key + signature_secret, private_key + application_id, api_key + api_secret + private_key + application_id, api_key + signature_secret + private_key + application_id
      */
-    public function testWhenNoConfigurationIsGivenExceptionIsRaised()
+    public function testWhenNoConfigurationIsGivenExceptionIsRaised($className)
     {
-        app(Client::class);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Please provide Nexmo API credentials. Possible combinations: api_key + api_secret, api_key + signature_secret, private_key + application_id, api_key + api_secret + private_key + application_id, api_key + signature_secret + private_key + application_id');
+
+        app($className);
     }
 }

--- a/tests/TestServiceProvider.php
+++ b/tests/TestServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Nexmo\Laravel\Tests;
 
-use Nexmo\Client;
+use Vonage\Client;
 
 class TestServiceProvider extends AbstractTestCase
 {
@@ -23,12 +23,14 @@ class TestServiceProvider extends AbstractTestCase
      * Test that we can create the Nexmo client
      * from container binding.
      *
+     * @dataProvider classNameProvider
+     *
      * @return void
      */
-    public function testClientResolutionFromContainer()
+    public function testClientResolutionFromContainer($className)
     {
-        $client = app(Client::class);
+        $client = app($className);
 
-        $this->assertInstanceOf(Client::class, $client);
+        $this->assertInstanceOf($className, $client);
     }
 }


### PR DESCRIPTION
While we added support for both namespaces via `vonage/nexmo-bridge`, the unit tests were pretty heavily tied to specific class names. This fixes the tests to work better for internal class checking, and as a side consequence makes it possible to create `Vonage\Client` as well as `Nexmo\Client` through the service provider.

This is not a customer-facing change, just cleans up the tests. The config options will be altered when we push this as `vonage/laravel`, and is a psuedo-prerequisite for #51 (I'd like the tests work before we cut another release).